### PR TITLE
Update RemoteDesktopTools.psm1

### DIFF
--- a/RemoteDesktopTools.psm1
+++ b/RemoteDesktopTools.psm1
@@ -171,7 +171,9 @@ A RDP session to server01 with the user LAPSAdmin and using the Get-LAPSPassword
             $User     = $Credential.UserName
             $Password = $Credential.GetNetworkCredential().Password
         } else {
-            $Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+	    $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
+	    $password = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr)
         }
     }
     process {


### PR DESCRIPTION
SecureStringToBSTR returns a BSTR because it's designed to work with COM (Component Object Model) APIs, which use BSTRs to represent strings. However, PtrToStringAuto is designed to work with null-terminated strings, which are the standard string representation in .NET.

To fix this, you can use the PtrToStringBSTR method instead of PtrToStringAuto. PtrToStringBSTR is specifically designed to work with BSTRs and will correctly convert the pointer to a .NET string.